### PR TITLE
Remove default values for $id parameter in Model

### DIFF
--- a/src/Tournament/Model/MatchRecord/MatchRecord.php
+++ b/src/Tournament/Model/MatchRecord/MatchRecord.php
@@ -9,7 +9,7 @@ use Tournament\Model\Participant\Participant;
 class MatchRecord extends \Tournament\Model\Base\DbItem
 {
    public function __construct(
-      ?int $id = null,
+      ?int $id,
       public readonly string $name,
       public readonly Category $category,
       public readonly Area $area,

--- a/src/Tournament/Model/Participant/Participant.php
+++ b/src/Tournament/Model/Participant/Participant.php
@@ -9,7 +9,7 @@ use Respect\Validation\Validator as v;
 class Participant extends \Tournament\Model\Base\DbItem
 {
    public function __construct(
-      ?int $id = null,                     // Unique identifier for the participant
+      ?int $id,                           // Unique identifier for the participant
       public readonly int $tournament_id, // Identifier for the tournament this participant belongs to
       public string $lastname,   // Last name of the participant
       public string $firstname,  // First name of the participant

--- a/src/Tournament/Model/Tournament/Tournament.php
+++ b/src/Tournament/Model/Tournament/Tournament.php
@@ -9,9 +9,9 @@ class Tournament extends \Tournament\Model\Base\DbItem
    public TournamentStatus $status;
 
    public function __construct(
-      ?int $id = null,             // Unique identifier for the tournament
-      public string $name,         // Name of the tournament
-      public string $date,         // Date of the tournament
+      ?int $id,                     // Unique identifier for the tournament
+      public string $name,          // Name of the tournament
+      public string $date,          // Date of the tournament
       public ?string $notes = null, // Additional notes about the tournament
       TournamentStatus|string $status = TournamentStatus::Planning, // Status of the tournament (e.g., scheduled, ongoing, completed)
    )


### PR DESCRIPTION
Optional Parameters only accepted on end of parameter list. Force explict setting of $id on instance creation.

fixes #4 