### PR TITLE
Add pool count configuration

### DIFF
--- a/src/Tournament/Model/Category/CategoryConfiguration.php
+++ b/src/Tournament/Model/Category/CategoryConfiguration.php
@@ -12,6 +12,7 @@ class CategoryConfiguration
       public int $num_rounds = 4,        // Number of rounds in the tournament
       public ?int $pool_winners = null,  // Number of winners from each pool (if applicable)
       public ?int $area_cluster = null,  // Number of concurrent participants per area (if applicable)
+      public ?int $max_pools = 0,        // Max number of pools (0 = unlimited)
    )
    {
       /* force-reset invalid values */
@@ -19,6 +20,7 @@ class CategoryConfiguration
       if (!$rules['num_rounds']->isValid($this->num_rounds) || !isset($this->num_rounds) ) $this->num_rounds = 4;
       if (!$rules['pool_winners']->isValid($this->pool_winners)) $this->pool_winners = null;
       if (!$rules['area_cluster']->isValid($this->area_cluster)) $this->area_cluster = null;
+      if (!$rules['max_pools']->isValid($this->max_pools)) $this->max_pools = 0;
    }
 
    public static function validationRules(): array
@@ -28,6 +30,7 @@ class CategoryConfiguration
          'num_rounds'    => v::optional(v::numericVal()->intVal()->min(2)->max(10)), // Number of rounds in the tournament
          'pool_winners'  => v::optional(v::numericVal()->intVal()->min(1)->max(3)),  // number of winners from each pool
          'area_cluster'  => v::optional(v::numericVal()->intVal()->min(1)),          // clustering of area distribution
+         'max_pools'     => v::optional(v::numericVal()->intVal()->min(0)),          // Max number of pools (0 = unlimited)
       ];
    }
 
@@ -37,6 +40,7 @@ class CategoryConfiguration
       if (isset($data['num_rounds']))   $this->num_rounds   = (int)$data['num_rounds'];
       if (isset($data['pool_winners'])) $this->pool_winners = empty($data['pool_winners']) ? null : (int)$data['pool_winners'];
       if (isset($data['area_cluster'])) $this->area_cluster = empty($data['area_cluster']) ? null : (int)$data['area_cluster'];
+      if (isset($data['max_pools']))    $this->max_pools    = (int)$data['max_pools'];
    }
 
    public static function load(string $json): self

--- a/src/Tournament/Model/TournamentStructure/TournamentStructure.php
+++ b/src/Tournament/Model/TournamentStructure/TournamentStructure.php
@@ -72,7 +72,8 @@ class TournamentStructure
       }
       elseif ($this->category->mode === CategoryMode::Combined)
       {
-         $this->pools = $this->createAutoPools($this->category->config->num_rounds, $this->category->config->pool_winners);
+         $cfg = $this->category->config;
+         $this->pools = $this->createAutoPools($cfg->num_rounds, $cfg->pool_winners, $cfg->max_pools);
          $this->ko = $this->fillKO( $this->createPoolKoFirstRound($this->pools, $this->category->config->pool_winners) );
       }
       else
@@ -145,11 +146,12 @@ class TournamentStructure
     * This method will create pools with a maximum size defined in the category configuration.
     * Autogeneration of pools is only valid for combined mode.
     */
-   private function createAutoPools(int $numRounds, ?int $winnersPerPool = null): PoolCollection
+   private function createAutoPools(int $numRounds, ?int $winnersPerPool = null, int $maxPools = 0): PoolCollection
    {
       $winnersPerPool ??= 2;
       $numSlots = pow(2, $numRounds);
       $numPools = pow(2, floor(log($numSlots / $winnersPerPool, 2))); // number of pools, must be a power of 2, rest filled up with BYEs
+      if( $maxPools > 0 ) $numPools = min($maxPools, $numPools);
       return PoolCollection::new( array_map(fn($i) => $this->factory->createPool($i+1), range(0, $numPools - 1)) );
    }
 
@@ -157,34 +159,45 @@ class TournamentStructure
     * Create a knockout structure based on the pools.
     * This method will distribute the pool winner start slots so that participants of the first pool will meet
     * as late as possible again.
+    * If there are any wildcards, this algorithm will assign them to the higher ranking participants according
+    * pool results first.
     *
     * This is done by iteratively halving the pool winner lists into smaller chunks, with a conflict resolution
-    * algorithm that determines the best canditates to add to each smaller chunk via some sort of cost analysis.
+    * algorithm that determines the best canditates to add to each smaller chunk by a simple cost analysis.
     */
    private function createPoolKoFirstRound(PoolCollection $pools, ?int $winnersPerPool = null): MatchNodeCollection
    {
       $winnersPerPool ??= 2;
       $poolsPerPlace = [array_fill(0, $winnersPerPool, $pools->keys())];
       $splitTarget = $winnersPerPool * $pools->count(); // target for splitting the pool winners into two halves
+      $dummy_pool_id = $pools->count() + 1; // track IDs of dummy pools during splitting, which will be replaced by a wildcard later.
       while ($splitTarget >= 4)
       {
          /* track usage of each pool while distributing pool winners, use pool ids as key */
          $nextRound = [];
-         $splitTarget /= 2; // halve the target for the next round
+         $splitTarget = ceil($splitTarget / 2); // halve the target for the next round, rounding up
          /* split down each current chunk into two new chunks */
          foreach ($poolsPerPlace as $chunk)
          {
+            /* add a dummy pool entry if not an even number of entries
+             * always add them at lowest rank, so they will be assigned to top ranks at match pairing
+             */
+            if(array_sum(array_map('count', $chunk)) % 2) array_unshift($chunk[$winnersPerPool - 1], $dummy_pool_id++);
+
             /* chunk format: [ 0 => [pool1_idx, pool2_idx, ...], 1 => [pool1_idx, pool2_idx, ...] ] */
             $poolUsage = array_fill_keys(array_merge(...$chunk), 0); // to track usage of each available pool
             $split_chunk = []; // the separated chunk for the next round
             $split_count = 0; // count how many pools we have split so far
             while ($split_count < $splitTarget)
             {
-               /* select one new candidate from each placement rank */
-               for ($i = 0; ($i < $winnersPerPool) && ($split_count < $splitTarget); $i++)
+               /* select one new candidate from each placement rank, which will result into selecting
+                * from a different pool each time - as a result, pool members will be separated across chunks
+                */
+               for ($i = 0; ($i < $winnersPerPool) && ($split_count < $splitTarget); ++$i)
                {
                   // find the pool with the least usage
                   $chunkPoolUsage = array_intersect_key($poolUsage, array_flip($chunk[$i]));
+                  if(empty($chunkPoolUsage)) continue;
                   $poolId = array_search(min($chunkPoolUsage), $chunkPoolUsage);
                   // add the pool to the split chunk
                   $split_chunk[$i][] = $poolId;
@@ -218,31 +231,31 @@ class TournamentStructure
             // create PoolWinnerSlot objects for each pool winner in the chunk
             foreach ($poolIds as $poolId)
             {
-               $slots[] = new PoolWinnerSlot($pools[$poolId], $place + 1); // place starts at 0, but we want it to start at 1
+               if( $pools->keyExists($poolId) ) // catch dummy pools that may have been generated during the splitting
+               {
+                  $slots[] = new PoolWinnerSlot($pools[$poolId], $place + 1); // place starts at 0, but we want it to start at 1
+               }
+               else
+               {
+                  $slots[] = new ByeSlot();
+               }
             }
          }
 
          if (count($slots) === 2)
          {
-            $firstRound[] = $this->factory->createKoNode($nextMatchId++, slotRed: $slots[0], slotWhite: $slots[1]);
+            $firstRound[] = $this->factory->createKoNode($nextMatchId++, slotRed: $slots[0], slotWhite: $slots[1] );
          }
-         elseif (count($slots) >= 3)
+         elseif(count($slots) === 3)
          {
+            // one BYE needed, pair it with the best ranking participant in this chunk
+            $firstRound[] = $this->factory->createKoNode($nextMatchId++, slotRed: $slots[0], slotWhite: new ByeSlot());
             $firstRound[] = $this->factory->createKoNode($nextMatchId++, slotRed: $slots[1], slotWhite: $slots[2]);
-
-            if (count($slots) === 3)
-            {
-               $firstRound[] = $this->factory->createKoNode($nextMatchId++, slotRed: $slots[0], slotWhite: new ByeSlot());
-            }
-            elseif (count($slots) === 4)
-            {
-               $firstRound[] = $this->factory->createKoNode($nextMatchId++, slotRed: $slots[0], slotWhite: $slots[3]);
-            }
-            else
-            {
-               // sanity check, impossible with the split algorithm above
-               throw new \LogicException('Unexpected number of slots in chunk: ' . count($slots));
-            }
+         }
+         else
+         {
+            // sanity check, impossible with the split algorithm above
+            throw new \LogicException('Unexpected number of slots in chunk: ' . count($slots));
          }
       }
       return $firstRound;

--- a/templates/tournament/settings/category.twig
+++ b/templates/tournament/settings/category.twig
@@ -11,6 +11,7 @@
   {{ form.select('mode', 'Modus', enum_options(category_modes), prev.mode ?? category.mode.value, errors['mode'], required=true, active=isActive) }}
   {{ form.input('number', 'num_rounds', 'Anzahl KO-Runden', prev.num_rounds ?? config.num_rounds, errors['num_rounds'], {'min':2, 'max': 10}, active=isActive) }}
   {{ form.input('number', 'pool_winners', 'Anzahl Pool-Sieger', prev.pool_winners ?? config.pool_winners, errors['pool_winners'], {'max': 3, 'min': 1}, active=isActive) }}
+  {{ form.input('number', 'max_pools', 'Maximale Anzahl Pools (0 = unbegrenzt)', prev.max_pools ?? config.max_pools, errors['max_pools'], {'min': 0}, active=isActive) }}
   {{ form.input('number', 'area_cluster', 'Kampfflächen-Cluster', prev.area_cluster ?? config.area_cluster, errors['area_cluster'], {'min': 1}, active=isActive)}}
   <input type="hidden" name="return_to" value="{{return_to}}">
   {{ form.submit('Speichern und neu generieren', active=isActive) }}


### PR DESCRIPTION
Diese Änderung fügt eine Konfiguration hinzu, mit der die Anzahl an Pools in der Vorrunde begrenzt werden kann, auch wenn der KO-Baum mehr Pools erlaubt.

Dafür wurde auch der Algorithmus für die Zuordnung der Startplätze in der KO-Endrunde überarbeitet, sodass die Wildcards/BYEs zuerst unter den Erstplatzierten aufgeteilt werden.

Beispiel:
<img width="875" height="711" alt="grafik" src="https://github.com/user-attachments/assets/54b1a0d2-ac99-471f-8b5f-79e215cdca9d" />

In diesem Bild ist Beispielhaft ein Turnier mit 4 KO-Runden, aber nur 5 statt 8 Pools erstellt worden.
Es ist zu sehen, dass nur Zweitplatzierte einen Kampf untereinander in der ersten Runde haben, während alle Erstplatzierten sofort weiter kommen. (Nur ein zweiter Platz hat ebenfalls eine Wildcard erhalten da in diesem Setup 6 Wildcards entstehen für 5 Pools).

Ein weiteres Beispiel:
<img width="898" height="666" alt="grafik" src="https://github.com/user-attachments/assets/b82b60d3-f55d-4839-83ea-0909f9f4b291" />

Das gleiche Turnier, jetzt aber mit 6 statt 5 Pools. In diesem setup haben ebenfalls nur Erstplatzierte eine Wildcard erhalten - jedoch nicht alle, da nun weniger Wildcards als Pools zur Verfügung stehen. In der ersten Runde treten zeitplatzierte gegen andere zweit- aber auch erstplatzierte an.