### PR TITLE
Rework html form elements and submit buttons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -427,16 +427,6 @@ table.entry-list td a:hover {
   background-color: #4455cc;
 }
 
-input[type="checkbox"] {
-  width: 1.2em;
-  height: 1.2em;
-  cursor: pointer;
-}
-
-label {
-   cursor: pointer;
-}
-
 .boxed-section {
   background-color: #fff;
   border: 1px solid #ddd;
@@ -458,7 +448,6 @@ label {
   gap: 1rem;
 }
 
-/* form box */
 #content > section {
   background-color: #fff;
   border: 1px solid #ddd;
@@ -477,22 +466,46 @@ h2 {
   padding-bottom: 0.5rem;
 }
 
-input[type="submit"],
+/* Formulare */
+.form-element {
+   margin: 1rem 0;
+}
+
+.form-element label>span:after {
+   /* erzwinge Zeilenumbruch nach jedem span-element */
+   content:" ";
+   display: block;
+}
+
+input[type="checkbox"] {
+   width: 1.2em;
+   height: 1.2em;
+   cursor: pointer;
+}
+
+label {
+   cursor: pointer;
+}
+
 button {
    background-color: #f0f0f0; /* neutral hellgrau */
    border: 1px solid #ccc;
    border-radius: 6px;
    padding: 0.5rem 1rem;
    transition: background 0.2s, color 0.2s;
+   margin-top: 1rem;
+   margin-right: 1rem;
 }
 
-input[type="submit"]:enabled,
+table button {
+   margin-top: 0;
+}
+
 button:enabled {
   color: #333;                 /* dunkler Text */
   cursor: pointer;
 }
 
-input[type="submit"]:enabled:hover,
 button:enabled:hover {
   background-color: #e0e0e0;   /* etwas dunkler beim Hover */
   color: #111;

--- a/templates/auth/login.twig
+++ b/templates/auth/login.twig
@@ -1,22 +1,20 @@
-{% include 'base/header.twig' with {
-  'heading': 'Login'
-}%}
+{% import 'base/form.twig' as form %}
 
-{% if error %}
-<p class="error">{{ error }}</p>
-{% endif %}
+{% include 'base/header.twig' %}
 
-<form method="post" action="{{ url_for('auth.login.attempt') }}">
-  <p>
-    <label>E-Mail: <input type="text" name="email" value="{{email}}" required></label>
-  </p>
-  <p>
-    <label>Passwort: <input type="password" name="password" required></label>
-  </p>
-  <p>
-    <button type="submit">Anmelden</button>
+<section>
+  <h2>Login</h2>
+
+  {% if error %}
+  <p class="error">{{ error }}</p>
+  {% endif %}
+
+  <form method="post" action="{{ url_for('auth.login.attempt') }}">
+    {{ form.input('text', 'email', 'E-Mail', email, required=true)}}
+    {{ form.input('password', 'password', 'Passwort', required=true)}}
+    {{ form.submit('Anmelden')}}
     <a href="{{ url_for('auth.password.request.form') }}">Passwort vergessen?</a>
-  </p>
-</form>
+  </form>
+</section>
 
 {% include 'base/footer.twig' %}

--- a/templates/auth/password_forgot.twig
+++ b/templates/auth/password_forgot.twig
@@ -1,19 +1,20 @@
-{% include 'base/header.twig' with {
-  'heading': 'Password zurücksetzen'
-}%}
+{% import 'base/form.twig' as form %}
+
+{% include 'base/header.twig' %}
+
+<section>
+<h2>Password zurücksetzen</h2>
 
 {% if error %}
 <p class="error">{{ error }}</p>
 {% endif %}
 
 <form method="post" action="{{ url_for('auth.password.request.send') }}">
-  <p>
-    <label>E-mail: <input type="text" name="email" value="{{email}}" required></label>
-  </p>
-  <p>
-    <button type="submit">Reset-Link schicken</button>
-  </p>
+  {{ form.input('text', 'email', 'E-Mail', email, required=true)}}
+  {{ form.submit('Reset-Link schicken')}}
 </form>
 <p><a href="{{ url_for('auth.login.form') }}">Zurück zum Login</a></p>
+
+</section>
 
 {% include 'base/footer.twig' %}

--- a/templates/auth/password_reset.twig
+++ b/templates/auth/password_reset.twig
@@ -1,23 +1,21 @@
-{% include 'base/header.twig' with {
-  'heading': 'Password neu setzen'
-}%}
+{% import 'base/form.twig' as form %}
+
+{% include 'base/header.twig' with %}
+
+<section>
+<h2>Password neu setzen</h2>
 
 {% if error %}
 <p class="error">{{ error }}</p>
 {% endif %}
 
 <form method="post" action="{{ url_for('auth.password.reset.update') }}">
-  <p>
-    <label>Passwort: <input type="password" name="password" required></label>
-  </p>
-  <p>
-    <label>Wiederholen: <input type="password" name="confirm_password" required></label>
-  </p>
-  <p>
-    <input type="hidden" name="token" value="{{token}}">
-    <input type="hidden" name="email" value="{{email}}">
-    <button type="submit">Password neu setzen</button>
-  </p>
+  <input type="hidden" name="token" value="{{token}}">
+  <input type="hidden" name="email" value="{{email}}">
+  {{ form.input('password', 'password', 'Passwort', required=true)}}
+  {{ form.input('password', 'confirm_password', 'Wiederholen', required=true)}}
+  {{ form.submit('Password neu setzen')}}
 </form>
+</section>
 
 {% include 'base/footer.twig' %}

--- a/templates/base/form.twig
+++ b/templates/base/form.twig
@@ -1,110 +1,108 @@
-{%- macro input(type, name, label, value, error='', attributes={}, required=false, active=true) -%}
-<p>
-  <label><span class="label_text">{{ label }}</span>
-  {% if active -%}
+{%- macro input(type, name, label, value='', error='', attributes={}, required=false, active=true) -%}
+<div class="form-element">
+  <label>
+    <span>{{ label }}</span>
     <input type="{{ type }}" name="{{ name }}" value="{{ value|e }}"
       {%- for attr, val in attributes %} {{attr}}="{{ val }}" {% endfor %}
-      {%- if required %} required{% endif %}>
-  {% else -%}
-    <span class="input_text">{{value|e|default('n/a')}}</span>
-  {% endif %}
+      {%- if required %} required{% endif -%}
+      {%- if not active %} disabled{% endif %}>
   </label>
   {%- if error is not empty %}
   <span class="error">{{ error|e|nl2br }}</span>
   {%- endif %}
-</p>
+</div>
 {%- endmacro %}
 
-{%- macro input_plain(type, name, value, error='', attributes={}, required=false, active=true) -%}
-{% if active %}
-<input type="{{ type }}" name="{{ name }}" value="{{ value|e }}"
-  {%- for attr, val in attributes %} {{attr}}="{{ val }}" {% endfor %}
-  {%- if required %} required{% endif %}>
-{%- if error is not empty %}
-<span class="error">{{ error|e|nl2br }}</span>
-{%- endif %}
-{% else -%}
-<span class="input_text">{{value|e|default('n/a')}}</span>
-{% endif %}
+{%- macro input_plain(type, name, value='', error='', attributes={}, required=false, active=true) -%}
+<div class="form-element-plain">
+  <input type="{{ type }}" name="{{ name }}" value="{{ value|e }}"
+    {%- for attr, val in attributes %} {{attr}}="{{ val }}" {% endfor %}
+    {%- if required %} required{% endif -%}
+    {%- if not active %} disabled{% endif %}>
+  {%- if error is not empty %}
+  <span class="error">{{ error|e|nl2br }}</span>
+  {%- endif %}
+</div>
 {%- endmacro %}
 
 {%- macro checkbox(name, label, value, checked=false, error='', attributes={}, active=true) -%}
-<p>
+<div class="form-element">
   <label>
     <input type="checkbox" name="{{ name }}" value="{{ value }}"
       {%- for attr, val in attributes %} {{attr }}="{{ val }}"{% endfor %}
       {%- if checked %} checked{% endif %}
-      {%- if not active %} disabled{%endif%}>
+      {%- if not active %} disabled{% endif %}>
     <span>{{ label }}</span></label>
   {%- if error is not empty %}
   <span class="error">{{ error|e|nl2br }}</span>
   {%- endif %}
-</p>
+</div>
 {%- endmacro %}
 
-{%- macro textarea(name, label, value, error='', attributes={}, required=false, active=true) -%}
-<p>
-  <label><span>{{ label }}</span>
-  {% if active -%}
+{%- macro textarea(name, label, value='', error='', attributes={}, required=false, active=true) -%}
+<div class="form-element">
+  <label>
+    <span>{{ label }}</span>
     <textarea name="{{ name }}"
-      {%- for attr, val in attributes %} {{ attr }}="{{ val }}" {% endfor -%}
-      {%- if required %} required{% endif-%}>{{ value|e }}</textarea>
-  {% else -%}
-    <span class="textarea_text">{{ value|e }}</span>
-  {% endif -%}
+      {%- for attr, val in attributes %} {{ attr }}="{{ val }}" {% endfor %}
+      {%- if required %} required{% endif %}
+      {%- if not active %} disabled{% endif -%}
+      >{{ value|e }}</textarea>
   </label>
-  {%- if error is not empty %}
+  {% if error is not empty -%}
   <span class="error">{{ error|e|nl2br }}</span>
   {%- endif %}
-</p>
+</div>
 {%- endmacro %}
 
 {%- macro select(name, label, options, selected=null, error='', attributes={}, required=false, active=true) -%}
-<p>
-  <label><span>{{ label }}</span>
-    {% if active -%}
+<div class="form-element">
+  <label>
+    <span>{{ label }}</span>
     <select name="{{ name }}"
       {%- for attr, val in attributes %} {{ attr }}="{{ val }}"{% endfor -%}
-      {%- if required %} required{% endif %}>
+      {%- if required %} required{% endif %}
+      {%- if not active %} disabled{% endif %}>
       {% if selected is null and options[''] is not defined -%}
       <option></option>
       {%- endif %}
-      {% for key, text in options %}
+      {% for key, text in options -%}
+      {% if active or (selected is not null and key==selected) -%}
       <option value="{{ key|e }}" {% if selected is not null and key==selected %}selected{% endif %}>{{ text|e }}</option>
-      {% endfor -%}
+      {%- endif %}
+      {%- endfor %}
     </select>
-    {% else -%}
-    <span class="input_text">{{ options[selected]|e|default('n/a') }}</span>
-    {% endif -%}
   </label>
   {%- if error is not empty %}
   <span class="error">{{ error|e|nl2br }}</span>
   {%- endif %}
-</p>
+</div>
 {%- endmacro %}
 
 {%- macro select_plain(name, options, selected=null, error='', attributes={}, required=false, active=true) -%}
-{% if active -%}
 <select name="{{ name }}"
   {%- for attr, val in attributes %} {{ attr }}="{{ val }}"{% endfor -%}
-  {%- if required %} required{% endif %}>
+  {%- if required %} required{% endif %}
+  {%- if not active %} disabled{% endif %}>
   {% if selected is null and options[''] is not defined -%}
   <option></option>
   {%- endif %}
-  {% for key, text in options %}
-  <option value="{{ key|e }}"{% if selected is not null and key==selected %} selected{% endif %}>{{ text|e }}</option>
-  {% endfor -%}
+  {% for key, text in options -%}
+  {% if active or (selected is not null and key==selected) -%}
+  <option value="{{ key|e }}" {% if selected is not null and key==selected %}selected{% endif %}>{{ text|e }}</option>
+  {%- endif %}
+  {%- endfor %}
 </select>
 {%- if error is not empty %}
 <span class="error">{{ error|e|nl2br }}</span>
 {%- endif %}
-{% else -%}
-<span class="input_text">{{ options[selected]|e|default('n/a') }}</span>
-{% endif -%}
 {%- endmacro %}
 
-{%- macro submit(label, name=null, value=null, active=true) -%}
-{% if active -%}
-<p><button type="submit" {%- if name is not empty %} name="{{name}}" value="{{value??label}}"{%endif%}>{{ label }}</button></p>
-{% endif -%}
+{%- macro submit(label, name='', value='', attributes={}, confirm='', active=true) -%}
+<button
+  {%- if name is not empty %} name="{{name}}" value="{{value}}"{% endif -%}
+  {%- for attr, val in attributes %} {{ attr }}="{{ val }}"{% endfor -%}
+  {%- if confirm is not empty %} onclick="return confirm('{{ confirm }}');"{% endif -%}
+  {%- if not active %} disabled{% endif -%}
+  >{{ label }}</button>
 {%- endmacro %}

--- a/templates/special_pages/db_selection.twig
+++ b/templates/special_pages/db_selection.twig
@@ -12,7 +12,7 @@
 <form action="{{url_for('dbmigration.update')}}" method="post">
   <input type="hidden" name="_METHOD" value="PATCH">
   {{ form.select('version', 'DB-Version', versions, current, required=true) }}
-  <button>Aktualisieren</button>
+  {{ form.submit('Aktualisieren') }}
 </form>
 
 </section>

--- a/templates/tournament/match/match.twig
+++ b/templates/tournament/match/match.twig
@@ -1,4 +1,5 @@
 {% import 'base/match.twig' as part %}
+{% import 'base/form.twig' as form %}
 
 {% if type == 'ko' %}
 {% set update_route, get_route = 'tournaments.categories.ko.matches.update', 'tournaments.categories.ko.matches.show' %}
@@ -17,12 +18,10 @@
   <input type="hidden" name="participant" value="{{participant.id}}">
   <input type="hidden" name="undo" value="{{undo.id}}">
   {% for name, pt in possible_pts -%}
-  <button name="action" value="{{pt}}">{{pt}}</button>
+  {{ form.submit(pt, 'action', pt) }}
   {% endfor -%}
-  <button name="action" value="undo"{%if undo is null%} disabled{%endif%}>Undo{%if undo is not null%} ({{undo.point}}){%endif%}</button>
-  <button name="action" value="winner"
-    {%- if not node.isModifiable() or node.getWinner() is same as(participant) %} disabled{%endif-%}
-  >Als Gewinner setzen</button>
+  {{ form.submit('Undo' ~ (undo? '(%s)'|format(undo.point) : ''), 'action', 'undo', active=undo is not null)}}
+  {{ form.submit('Als Gewinner setzen', 'action', 'winner', active=node.isModifiable() and node.getWinner() is not same as(participant)) }}
 </form>
 {% endmacro -%}
 
@@ -78,9 +77,7 @@
         {% if node.tiesAllowed() -%}
         <form method="post" action="{{url_for(update_route, route_context.args)}}" class="match_control">
           <input type="hidden" name="_METHOD" value="PATCH">
-          <button name="action" value="tie"
-          {%- if not node.isModifiable() or node.isTied() %} disabled{%endif-%}
-          >Unentschieden</button>
+          {{ form.submit('Unentschieden', 'action', 'tie', active=node.isModifiable() and not node.isTied()) }}
         {%- endif %}
       </td>
       <td colspan="3" class="controls whiteside">

--- a/templates/tournament/navigation/category_KO.twig
+++ b/templates/tournament/navigation/category_KO.twig
@@ -27,7 +27,7 @@
 {% if policy.isActionAllowed('ManageSetup') %}
 <section>
 <form action="{{url_for('tournaments.categories.shuffleParticipants', route_context.args)}}" method="post">
-  <button type="submit">Teilnehmer neu verteilen</button>
+{{ form.submit('Teilnehmer neu verteilen')}}
 </form>
 </section>
 {% endif %}

--- a/templates/tournament/navigation/category_Pool.twig
+++ b/templates/tournament/navigation/category_Pool.twig
@@ -38,7 +38,7 @@
 {% if policy.isActionAllowed('ManageSetup') %}
 <section>
 <form action="{{url_for('tournaments.categories.shuffleParticipants', route_context.args)}}" method="post">
-  <button type="submit">Teilnehmer neu verteilen</button>
+{{ form.submit('Teilnehmer neu verteilen')}}
 </form>
 </section>
 {% endif %}

--- a/templates/tournament/navigation/category_home.twig
+++ b/templates/tournament/navigation/category_home.twig
@@ -25,7 +25,7 @@
 <section>
   <h2>Test-Optionen</h2>
   <form action="{{url_for('tournaments.categories.resetMatchRecords', route_context.args)}}" method="post">
-    <button type="submit">Aktuellen Turnierfortschritt löschen</button>
+  {{ form.submit('Aktuellen Turnierfortschritt löschen')}}
   </form>
 </section>
 {% endif %}

--- a/templates/tournament/navigation/pool_home.twig
+++ b/templates/tournament/navigation/pool_home.twig
@@ -18,14 +18,14 @@
   {%- endif %}
   {% if pool.needsDecisionRound() -%}
   <form method="post" action="{{url_for('tournaments.categories.pools.decision.add', route_parameters)}}" class="pool_control" id="tie_break_match_add">
-    <button>Entscheidungsrunde hinzufügen</button>
+  {{ form.submit('Entscheidungsrunde hinzufügen') }}
   </form>
   {% endif %}
   {% if pool.getCurrentDecisionRound() -%}
   <form method="post" action="{{url_for('tournaments.categories.pools.decision.delete', route_parameters|merge({'decision_round': pool.getCurrentDecisionRound()})) }}" class="pool_control"
     id="tie_break_match_delete">
-    <input type="hidden" name="_METHOD" value="DELETE">
-    <button>Letzte Entscheidungsrunde löschen</button>
+  <input type="hidden" name="_METHOD" value="DELETE">
+  {{ form.submit('Letzte Entscheidungsrunde löschen') }}
   </form>
   {% endif %}
 </section>

--- a/templates/tournament/participants/details.twig
+++ b/templates/tournament/participants/details.twig
@@ -39,7 +39,7 @@
         {% if errors.categories %}<p class="error">{{errors.categories}}</p>{%endif%}
       </tbody>
     </table>
-    <button>Speichern</button>
+    {{ form.submit('Speichern') }}
   </form>
 </section>
 

--- a/templates/tournament/participants/overview.twig
+++ b/templates/tournament/participants/overview.twig
@@ -43,7 +43,7 @@
           <a href="{{ url_for('tournaments.participants.show', route_context.args|merge({'participantId': participant.id})) }}">Bearbeiten</a>
           <form method="POST" action="{{ url_for('tournaments.participants.delete', route_context.args|merge({'participantId': participant.id})) }}">
             <input type="hidden" name="_METHOD" value="DELETE">
-            <button onclick="return confirm('{{ participant.lastname }}, {{ participant.firstname }} wirklich löschen?');">Löschen</button>
+            {{ form.submit('Löschen', confirm='%s, %s wirklich löschen?'|format(participant.lastname, participant.firstname)) }}
           </form>
         </td>
         <td>{{ participant.lastname }}, {{ participant.firstname }}</td>
@@ -70,7 +70,7 @@
 <h2>Teilnehmer importieren</h2>
 <form method="POST" action="{{ url_for('tournaments.participants.import.store', { 'tournamentId': tournament.id }) }}" id="participant_upload_form" enctype="multipart/form-data">
   {{ form.input('file', 'participant_file', 'Datei (CSV oder Excel)', '', errors.file, attributes={'accept':".csv,.xlsx,.xls,.ods"}) }}
-  {{ form.submit('Importieren', attributes={'class':'form-btn'}) }}
+  {{ form.submit('Importieren') }}
 </form>
 </section>
 
@@ -90,8 +90,7 @@
       <p class="error">{{errors.categories}}</p>
       {%endif-%}
     </fieldset>
-
-    {{ form.submit('Hinzufügen', attributes={'class':'form-btn'}) }}
+    {{ form.submit('Hinzufügen') }}
   </form>
 </section>
 

--- a/templates/tournament/participants/upload_preview.twig
+++ b/templates/tournament/participants/upload_preview.twig
@@ -12,12 +12,15 @@
   {{ form.input('text', 'club', "Verband/Verein", club, errors.club, { 'maxlength': 100 }) }}
   {{ form.select('category', 'Kategorie (global)', category_sel, category, errors.category) }}
   {{ form.input('number', 'start_row', "Importieren ab Zeile", start_row, errors.start_row, {'min': 1, 'max': import.rows|length}, required=true)}}
-  <button formmethod="GET" formaction="{{ url_for('tournaments.participants.import.show', route_context.args) }}">Vorschau aktualisieren</button>
-  <button>Importieren</button>
+  {{ form.submit('Vorschau aktualisieren', attributes={
+        formmethod: "GET",
+        formaction: url_for('tournaments.participants.import.show', route_context.args)
+  })}}
+  {{ form.submit('Importieren') }}
 </form>
 <form method="post" action="{{ url_for('tournaments.participants.import.delete', route_context.args) }}">
   <input type="hidden" name="_METHOD" value="DELETE">
-  <button>Import abbrechen</button>
+  {{ form.submit('Import abbrechen') }}
 </form>
 <div class="scroll-frame">
 <table class="spreadsheet">

--- a/templates/tournament/settings/tournament.twig
+++ b/templates/tournament/settings/tournament.twig
@@ -49,18 +49,26 @@
     <tbody>
       {% for owner in route_context.tournament.owners -%}
       <tr><td>{{ owner.display_name }}</td>
-          <td><form method="POST" action="{{url_for('tournaments.removeOwner', route_context.args)}}">
+          {% if policy.isActionAllowed('ManageOwners') -%}
+          <td>
+            <form method="POST" action="{{url_for('tournaments.removeOwner', route_context.args)}}">
             <input type="hidden" name="_METHOD" value="PATCH">
             <input type="hidden" name="user_id" value="{{owner.id}}">
-            {{ form.submit('Entfernen', active=policy.isActionAllowed('ManageOwners')) }}</form>
+            {{ form.submit('Entfernen')}}
+            </form>
           </td>
+          {%- else -%}
+          <td>---</td>
+          {%- endif %}
       </tr>
       {%- endfor %}
       {% if policy.isActionAllowed('ManageOwners') -%}
       <tr><td>{{ form.select_plain("user_id", available_owners, attributes: { 'form': 'add_owner_form' }) }}</td>
-          <td><form method="POST" action="{{url_for('tournaments.addOwner', route_context.args)}}" id="add_owner_form">
+          <td>
+            <form method="POST" action="{{url_for('tournaments.addOwner', route_context.args)}}" id="add_owner_form">
             <input type="hidden" name="_METHOD" value="PATCH">
-            {{ form.submit('Hinzufügen') }}</form>
+            {{ form.submit('Hinzufügen') }}
+            </form>
           </td>
       </tr>
       {%- endif %}

--- a/templates/user/account.twig
+++ b/templates/user/account.twig
@@ -27,13 +27,11 @@
     {% elseif errors.password -%}
     <p class="error">{{ errors.password }}</p>
     {%- endif %}
-    <p><label>Aktuelles Passwort: <input type="password" name="current_password"></label></p>
-    <p><label>Neues Passwort: <input type="password" name="new_password"></label></p>
-    <p><label>Neues Passwort wiederholen: <input type="password" name="new_password_repeat"></label></p>
+    {{ form.input('password', 'current_password', 'Aktuelles Passwort', required=true)}}
+    {{ form.input('password', 'new_password', 'Neues Passwort', required=true)}}
+    {{ form.input('password', 'new_password_repeat', 'Neues Passwort wiederholen', required=true)}}
   </fieldset>
-  <p>
-    <button type="submit">Aktualisieren</button>
-  </p>
+  {{ form.submit('Aktualisieren')}}
 </form>
 </div>
 

--- a/templates/user/user_create.twig
+++ b/templates/user/user_create.twig
@@ -12,7 +12,7 @@
   {% endif %}
   <form method="post" action="{{ url_for('users.store') }}">
     {{ form.input('email', 'email', 'E-Mail', prev.email, errors.email, {'maxlength':255}, required=true) }}
-    <p><button type="submit">Anlegen</button></p>
+    {{ form.submit('Anlegen')}}
   </form>
 </section>
 

--- a/templates/user/user_details.twig
+++ b/templates/user/user_details.twig
@@ -33,20 +33,18 @@
     </fieldset>
     {{ form.checkbox('is_active', 'Benutzer aktiv', true, prev? prev.is_active : user.is_active, active: form_active)}}
     {% if form_active -%}
-      <p>
-        <input type="submit" value="Speichern">
-      </p>
+    {{ form.submit('Speichern')}}
     {%- endif %}
   </form>
   {% if form_active -%}
     {% if user.password_hash is empty -%}
     <form action="{{ url_for('users.sendWelcome', {'userId': user.id}) }}" method="post">
-      <button>Willkommens-Mail schicken</button>
+    {{ form.submit('Willkommens-Mail schicken')}}
     </form>
     {%- endif %}
     <form method="post" action="{{ url_for('users.delete', {'userId': user.id}) }}">
       <input type="hidden" name="_METHOD" value="DELETE">
-      <button onclick="return confirm('{{user.display_name}} wirklich löschen?');">Nutzer löschen</button>
+      {{ form.submit('Nutzer löschen', confirm=user.display_name ~ ' wirklich löschen?') }}
     </form>
   {%- endif %}
 </section>

--- a/templates/user/user_management.twig
+++ b/templates/user/user_management.twig
@@ -30,7 +30,7 @@
           {% if buttons_active -%}
           <form method="post" action="{{ url_for('users.delete', {'userId': user.id}) }}">
             <input type="hidden" name="_METHOD" value="DELETE">
-            <button onclick="return confirm('{{user.display_name}} wirklich löschen?');">Löschen</button>
+            {{ form.submit('Löschen', confirm='%s wirklich löschen?'|format(user.display_name)) }}
           </form>
           {%- endif %}
       </td>
@@ -61,7 +61,7 @@
           {% if buttons_active -%}
           <form method="post" action="{{ url_for('users.delete', {'userId': user.id}) }}">
             <input type="hidden" name="_METHOD" value="DELETE">
-            <button onclick="return confirm('{{user.display_name}} wirklich löschen?');">Löschen</button>
+            {{ form.submit('Löschen', confirm='%s wirklich löschen?'|format(user.display_name)) }}
           </form>
           {%- endif %}
       </td>


### PR DESCRIPTION
- unify button setup by strictly using the corresponding form.submit macro
- unify "disabled" handling: still always show a form element, but disable it only if not active
- natively support a "confirm" message in form.submit macro
- use div instead of p to cluster form elements