### PR TITLE
fix FK adding in phinx migrations

### DIFF
--- a/db/migrations/20250928110000_add_table_matches.php
+++ b/db/migrations/20250928110000_add_table_matches.php
@@ -20,11 +20,11 @@ final class AddTableMatches extends AbstractMigration
             ->addColumn('tie_break', 'boolean', ['null' => false, 'default' => false])
             ->addColumn('created_at', 'datetime', ['default' => 'CURRENT_TIMESTAMP'])
             ->addColumn('finalized_at', 'datetime', ['null' => true, 'default' => null])
-            ->addForeignKey('category_id', 'categories', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE'])
-            ->addForeignKey('white_id', 'participants', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE'])
-            ->addForeignKey('red_id', 'participants', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE'])
-            ->addForeignKey('winner_id', 'participants', 'id', ['delete'=> 'RESTRICT', 'update'=> 'CASCADE'])
-            ->addForeignKey('area_id', 'areas', 'id', ['delete'=> 'RESTRICT', 'update'=> 'CASCADE'])
+            ->addForeignKey('category_id', 'categories', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE', 'constraint' => 'matches_category_fk'])
+            ->addForeignKey('white_id', 'participants', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE', 'constraint' => 'matches_white_participant_fk'])
+            ->addForeignKey('red_id', 'participants', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE', 'constraint' => 'matches_red_participant_fk'])
+            ->addForeignKey('winner_id', 'participants', 'id', ['delete'=> 'RESTRICT', 'update'=> 'CASCADE', 'constraint' => 'matches_winner_fk'])
+            ->addForeignKey('area_id', 'areas', 'id', ['delete'=> 'RESTRICT', 'update'=> 'CASCADE', 'constraint' => 'matches_area_fk'])
             ->addIndex(['category_id', 'name'], ['unique' => true])
             ->create();
       }

--- a/db/migrations/20251007170000_add_table_match_points.php
+++ b/db/migrations/20251007170000_add_table_match_points.php
@@ -16,9 +16,9 @@ final class AddTableMatchPoints extends AbstractMigration
             ->addColumn('point', 'char', ['limit' => 1, 'null' => false])
             ->addColumn('given_at', 'datetime', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
             ->addColumn('caused_by',  'integer', ['null' => true, 'signed' => false])
-            ->addForeignKey('match_id', 'matches', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE'])
-            ->addForeignKey('participant_id', 'participants', 'id', ['delete'=> 'RESTRICT', 'update'=> 'CASCADE'])
-            ->addForeignKey('caused_by', 'match_points', 'id', ['delete' => 'SET NULL', 'update' => 'CASCADE'])
+            ->addForeignKey('match_id', 'matches', 'id', ['delete'=> 'CASCADE', 'update'=> 'CASCADE', 'constraint' => 'match_points_match_fk'])
+            ->addForeignKey('participant_id', 'participants', 'id', ['delete'=> 'RESTRICT', 'update'=> 'CASCADE', 'constraint' => 'match_points_participant_fk'])
+            ->addForeignKey('caused_by', 'match_points', 'id', ['delete' => 'SET NULL', 'update' => 'CASCADE', 'constraint' => 'match_points_causedby_fk'])
             ->create();
 
       }

--- a/db/migrations/20260202170000_user_extension.php
+++ b/db/migrations/20260202170000_user_extension.php
@@ -22,8 +22,8 @@ final class UserExtension extends AbstractMigration
       $this->table('user_roles', ['id' => false, 'primary_key' => ['user_id', 'role_id']])
          ->addColumn('user_id', 'integer', ['signed' => false, 'null' => false])
          ->addColumn('role_id', 'integer', ['signed' => false, 'null' => false])
-         ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE', 'constraint' => 'USER_ID'])
-         ->addForeignKey('role_id', 'roles', 'id', ['delete' => 'CASCADE', 'constraint' => 'ROLE_ID'])
+         ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE', 'constraint' => 'user_roles_user_fk'])
+         ->addForeignKey('role_id', 'roles', 'id', ['delete' => 'CASCADE', 'constraint' => 'user_roles_role_fk'])
          ->create();
 
       /* translate the admin flag to the new role system */

--- a/db/migrations/20260223140000_tournament_owners.php
+++ b/db/migrations/20260223140000_tournament_owners.php
@@ -11,8 +11,8 @@ final class TournamentOwners extends AbstractMigration
       $this->table('tournament_owners', ['id' => false, 'primary_key' => ['user_id', 'tournament_id']])
          ->addColumn('user_id', 'integer', ['null' => false, 'signed' => false])
          ->addColumn('tournament_id', 'integer', ['null' => false, 'signed' => false])
-         ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE', 'constraint' => 'USER_ID'])
-         ->addForeignKey('tournament_id', 'tournaments', 'id', ['delete' => 'CASCADE', 'constraint' => 'TOURNAMENT_ID'])
+         ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE', 'constraint' => 'tournament_owners_user_fk'])
+         ->addForeignKey('tournament_id', 'tournaments', 'id', ['delete' => 'CASCADE', 'constraint' => 'tournament_owners_tournament_fk'])
          ->create();
    }
 }

--- a/db/migrations/20260226123000_drop_session_user_id.php
+++ b/db/migrations/20260226123000_drop_session_user_id.php
@@ -22,7 +22,7 @@ final class DropSessionUserId extends AbstractMigration
    {
       $this->table('sessions')
          ->addColumn('user_id', 'integer', ['signed' => false, 'after' => 'id'])
-         ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE'])
+         ->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE', 'constraint' => 'sessions_user_fk'])
          ->save();
 
       $this->table('users')


### PR DESCRIPTION
explicitly name all constraints.
phinx just assigns numbers to unnamed constraints, and then fails to delete constraints that only have a number as name if a migrations in the other direction is attempted.