### PR TITLE
ParticipantHandler: fix pool load

### DIFF
--- a/src/Base/Model/ObjectCollection.php
+++ b/src/Base/Model/ObjectCollection.php
@@ -258,9 +258,18 @@ class ObjectCollection implements \IteratorAggregate, \Countable, \ArrayAccess
       return static::new(array_merge($this->elements, $other), $this->element_type);
    }
 
-   public function ksort(int $flags = SORT_REGULAR): void
+   public function ksort(int $flags = SORT_REGULAR): static
    {
-      ksort($this->elements, $flags);
+      $cpy = $this->elements;
+      ksort($cpy, $flags);
+      return static::_spawn($cpy);
+   }
+
+   public function usort(callable $callback): static
+   {
+      $cpy = $this->elements;
+      usort($cpy, $callback);
+      return static::_spawn($cpy);
    }
 
    /**

--- a/src/Tournament/Model/TournamentStructure/MatchNode/MatchNode.php
+++ b/src/Tournament/Model/TournamentStructure/MatchNode/MatchNode.php
@@ -31,7 +31,7 @@ class MatchNode
    {
       if( $this->slotRed === $this->slotWhite )
       {
-         throw new \DomainException("invalid match: red and white slot must be different");
+         throw new \DomainException("invalid match: red and white slot must be different - $node_name");
       }
 
       $this->setName($node_name);
@@ -72,28 +72,32 @@ class MatchNode
 
       if( !$this->isReal() )
       {
-         throw new \LogicException("attempt to assign a match record to non-real match");
+         throw new \LogicException("attempt to assign a match record to non-real match: " . $this->getName());
       }
 
       if( $matchRecord->name !== $this->name )
       {
-         throw new \DomainException("inconsistent match record: name does not match");
+         throw new \DomainException("inconsistent match record: name does not match: " . $this->getName());
       }
 
       /* make sure the contained participants match with the participants according the tree */
       $p_red   = $this->slotRed->getParticipant();
       $p_white = $this->slotWhite->getParticipant();
 
-      if( !isset($p_red))   throw new \DomainException("cannot assign match record: no valid red participant");
-      if( !isset($p_white)) throw new \DomainException("cannot assign match record: no valid white participant");
+      if( !isset($p_red))   throw new \DomainException("cannot assign match record: no valid red participant: " . $this->getName());
+      if( !isset($p_white)) throw new \DomainException("cannot assign match record: no valid white participant: " . $this->getName());
 
       if ($p_red->id !== $matchRecord->redParticipant->id)
       {
-         throw new \DomainException("inconsistent match record: red participant does not match");
+         $rid = $p_red->id;
+         $rid2 = $matchRecord->redParticipant->id;
+         $ridw = $p_white->id;
+         $ridw2 = $matchRecord->whiteParticipant->id;
+         throw new \DomainException("inconsistent match record: red participant does not match: $rid - $rid2 - $ridw - $ridw2" . $this->getName());
       }
       if ($p_white->id !== $matchRecord->whiteParticipant->id)
       {
-         throw new \DomainException("inconsistent match record: white participant does not match");
+         throw new \DomainException("inconsistent match record: white participant does not match: " . $this->getName());
       }
 
       /* update this note with those inputs */

--- a/src/Tournament/Model/TournamentStructure/ParticipantHandler.php
+++ b/src/Tournament/Model/TournamentStructure/ParticipantHandler.php
@@ -117,10 +117,13 @@ class ParticipantHandler
          }
       }
 
-      /* forward the collected participants to each pool */
+      /* forward the collected participants to each pool.
+       * Make sure they are always in the same order according slot number
+       */
+      $sorter = fn($a,$b) => $a->categories[$this->struc->category->id]->slot_name <=> $b->categories[$this->struc->category->id]->slot_name;
       foreach ($pool_participants as $id => $col)
       {
-         $this->struc->pools[$id]->setParticipants($col);
+         $this->struc->pools[$id]->setParticipants($col->usort($sorter));
       }
    }
 
@@ -412,8 +415,7 @@ class ParticipantHandler
          if ($node->slotRed->getName())   $result[$node->slotRed->getName()] = $node->slotRed;
          if ($node->slotWhite->getName()) $result[$node->slotWhite->getName()] = $node->slotWhite;
       }
-      $result->ksort(SORT_STRING);
-      return $result;
+      return $result->ksort(SORT_STRING);
    }
 
    /**

--- a/tests/Tournament/Model/TournamentStructure/ParticipantHandlerTest.php
+++ b/tests/Tournament/Model/TournamentStructure/ParticipantHandlerTest.php
@@ -160,7 +160,7 @@ class ParticipantHandlerTest extends TestCase
 
       $structure2 = new TournamentStructure($category, AreaCollection::new());
       $structure2->generateStructure();
-      $structure2->getParticipantHandler()->loadParticipants($participants);
+      $structure2->getParticipantHandler()->loadParticipants($participants->reverse()); // explicitly provide them in a different order
 
       $this->assertEquals($structure, $structure2);
    }
@@ -178,7 +178,7 @@ class ParticipantHandlerTest extends TestCase
 
       $structure2 = new TournamentStructure($category, AreaCollection::new());
       $structure2->generateStructure();
-      $structure2->getParticipantHandler()->loadParticipants($participants);
+      $structure2->getParticipantHandler()->loadParticipants($participants->reverse()); // explicitly provide them in a different order
 
       $this->assertEquals($structure, $structure2);
    }


### PR DESCRIPTION
- make sure to add participants always in the same order according starting slot name, to have a reproducable match generation.

regression introduced via #45 - due to non-deterministic participant loading into pools, already existing match records got invalidated.