### PR TITLE
Area Device Account Access guarding in MW

### DIFF
--- a/src/Tournament/Controller/Device/AreaDeviceViewController.php
+++ b/src/Tournament/Controller/Device/AreaDeviceViewController.php
@@ -9,8 +9,6 @@ use Slim\Views\Twig;
 
 use Tournament\Model\TournamentStructure\TournamentStructure;
 use Tournament\Model\TournamentStructure\MatchNode\MatchRoundCollection;
-use Tournament\Model\TournamentStructure\MatchNode\MatchNode;
-use Tournament\Model\TournamentStructure\Pool\Pool;
 
 use Tournament\Service\MatchHandlingService;
 use Tournament\Service\TournamentStructureService;
@@ -21,7 +19,6 @@ use Tournament\Policy\AuthContext;
 use Base\Service\PrgService;
 
 use Tournament\Exception\EntityNotFoundException;
-use Slim\Exception\HttpForbiddenException;
 
 class AreaDeviceViewController
 {
@@ -32,20 +29,6 @@ class AreaDeviceViewController
       private Twig $view,
    )
    {
-   }
-
-   /**
-    * device access is limited to a specific area.
-    * But for knowing whether a specific entity is mapped to a specific area,
-    * we need to load the whole structure and match record list, which we do not
-    * want to do on policy level. Therefore the area access is checked here on Controller level
-    */
-   private function guardAccess(Request $request, Pool|MatchNode $entity, AuthContext $auth): void
-   {
-      if ($entity->getArea() !== $auth->area)
-      {
-         throw new HttpForbiddenException($request, 'Zugriff nicht erlaubt');
-      }
    }
 
    /**
@@ -72,7 +55,7 @@ class AreaDeviceViewController
       $auth = $request->getAttribute('auth_context');
 
       // Load the tournament structure for this category
-      $structure = $this->structureLoadService->load($ctx->category);
+      $structure = $request->getAttribute('tournament_structure') ?? $this->structureLoadService->load($ctx->category);
 
       return $this->view->render($response, 'device/categories_show.twig', [
          'pools'     => $structure->pools->filter(fn($p) => $p->getArea() === $auth->area),
@@ -90,11 +73,9 @@ class AreaDeviceViewController
       /** @var AuthContext $auth */
       $auth = $request->getAttribute('auth_context');
 
-      $structure ??= $this->structureLoadService->load($ctx->category);
-      $pool = $structure->pools[$args['pool']] ?? throw new EntityNotFoundException($request, 'Pool not found');
-
-      /** @var Pool $pool */
-      $this->guardAccess($request, $pool, $auth);
+      /* load the structure and find the current pool */
+      $structure = $request->getAttribute('tournament_structure') ?? $this->structureLoadService->load($ctx->category);
+      $pool = $structure->pools[$ctx->pool_name] ?? throw new EntityNotFoundException($request, 'Pool not found');
 
       /* select an active match from this pool */
       $matches = $pool->getMatchList();
@@ -125,13 +106,10 @@ class AreaDeviceViewController
    {
       /** @var RouteArgsContext $ctx */
       $ctx = $request->getAttribute('route_context');
-      /** @var AuthContext $auth */
-      $auth = $request->getAttribute('auth_context');
 
-      $structure = $this->structureLoadService->load($ctx->category);
-      $pool = $structure->pools[$args['pool']] ?? throw new EntityNotFoundException($request, 'Pool not found');
-
-      $this->guardAccess($request, $pool, $auth);
+      /* load the structure and find the current pool */
+      $structure = $request->getAttribute('tournament_structure') ?? $this->structureLoadService->load($ctx->category);
+      $pool = $structure->pools[$ctx->pool_name] ?? throw new EntityNotFoundException($request, 'Pool not found');
 
       $error = $this->matchService->addPoolTieBreak($pool);
 
@@ -152,13 +130,10 @@ class AreaDeviceViewController
    {
       /** @var RouteArgsContext $ctx */
       $ctx = $request->getAttribute('route_context');
-      /** @var AuthContext $auth */
-      $auth = $request->getAttribute('auth_context');
 
-      $structure = $this->structureLoadService->load($ctx->category);
-      $pool = $structure->pools[$args['pool']] ?? throw new EntityNotFoundException($request, 'Pool not found');
-
-      $this->guardAccess($request, $pool, $auth);
+      /* load the structure and find the current pool */
+      $structure = $request->getAttribute('tournament_structure') ?? $this->structureLoadService->load($ctx->category);
+      $pool = $structure->pools[$ctx->pool_name] ?? throw new EntityNotFoundException($request, 'Pool not found');
 
       $error = $this->matchService->deletePoolTieBreak($pool, (int)$args['decision_round']);
       /* forward to output page */
@@ -172,7 +147,7 @@ class AreaDeviceViewController
       }
    }
 
-   public function showMatch(Request $request, Response $response, array $args, ?TournamentStructure $structure = null, $error = null): Response
+   public function showMatch(Request $request, Response $response, array $args, ?string $error = null): Response
    {
       /** @var RouteArgsContext $ctx */
       $ctx = $request->getAttribute('route_context');
@@ -180,10 +155,8 @@ class AreaDeviceViewController
       $auth = $request->getAttribute('auth_context');
 
       /* load the structure and find the current node/match */
-      $structure ??= $this->structureLoadService->load($ctx->category);
+      $structure = $request->getAttribute('tournament_structure') ?? $this->structureLoadService->load($ctx->category);
       $node = $structure->findNode($ctx->match_name, $ctx->pool_name ?? false) ?? new EntityNotFoundException($request, "unknown Match '{$ctx->match_name}'");
-
-      $this->guardAccess($request, $node, $auth);
 
       /* get pointers to the previous and next "real" matches for our area */
       $matchList = $structure->getFinaleRounds()->filterRounds(fn($n) => $n->isReal() && $n->getArea() === $auth->area);
@@ -203,21 +176,17 @@ class AreaDeviceViewController
    {
       /** @var RouteArgsContext $ctx */
       $ctx = $request->getAttribute('route_context');
-      /** @var AuthContext $auth */
-      $auth = $request->getAttribute('auth_context');
 
       /* load the structure and find the current node/match */
-      $structure = $this->structureLoadService->load($ctx->category);
+      $structure = $request->getAttribute('tournament_structure') ?? $this->structureLoadService->load($ctx->category);
       $node = $structure->findNode($ctx->match_name, $ctx->pool_name ?? false) ?? new EntityNotFoundException($request, "unknown Match '{$ctx->match_name}'");
-
-      $this->guardAccess($request, $node, $auth);
 
       /* evaluate the match update data via our match service */
       $error = $this->matchService->updateMatchPoint($node, (array)$request->getParsedBody());
 
       if ($error)
       {
-         return $this->showMatch($request, $response, $args, $structure, $error);
+         return $this->showMatch($request, $response, $args, $error);
       }
       else
       {

--- a/src/Tournament/Middleware/AreaDeviceAccessGuard.php
+++ b/src/Tournament/Middleware/AreaDeviceAccessGuard.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Tournament\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use Slim\Exception\HttpForbiddenException;
+use Tournament\Exception\EntityNotFoundException;
+
+use Tournament\Policy\AuthContext;
+use Tournament\Service\RouteArgsContext;
+use Tournament\Service\TournamentStructureService;
+
+/**
+ * middleware to guard access for area device accounts - only grant access
+ * if the entity (pool, matchnode) access via the current route is assigned
+ * to the right area
+ */
+class AreaDeviceAccessGuard implements MiddlewareInterface
+{
+   public function __construct(
+      private TournamentStructureService $structureLoadService
+   )
+   {
+   }
+
+   /**
+    * guard processing
+    */
+   public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+   {
+      /** @var RouteArgsContext $ctx */
+      $ctx = $request->getAttribute('route_context');
+      /** @var AuthContext $auth */
+      $auth = $request->getAttribute('auth_context');
+
+      if( !$auth->area )
+      {
+         throw new \LogicException("Area Device guard entered for user without area restriction");
+      }
+
+      if( $ctx->match_name || $ctx->pool_name )
+      {
+         $structure = $this->structureLoadService->load($ctx->category);
+         $entity = $ctx->match_name? $structure->findNode($ctx->match_name, $ctx->pool_name ?? false)
+                 :                   $structure->pools[$ctx->pool_name];
+
+         if( !$entity )
+         {
+            throw new EntityNotFoundException($request, 'target not found');
+         }
+
+         if ($entity->getArea() !== $auth->area)
+         {
+            throw new HttpForbiddenException($request, 'Zugriff nicht erlaubt');
+         }
+
+         $request = $request->withAttribute('tournament_structure', $structure);
+      }
+
+      return $handler->handle($request);
+   }
+
+   /**
+    * factory method to create the middleware with dependencies from the container
+    */
+   public static function create(
+      \Slim\App $app,
+      ?TournamentStructureService $structureLoadService = null,
+   ): self
+   {
+      $container = $app->getContainer();
+      $structureLoadService ??= $container->get(TournamentStructureService::class);
+      return new self($structureLoadService);
+   }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -73,6 +73,9 @@ return function (\Slim\App $app)
    // General authorization checks
    $authGuard = \Base\Middleware\AuthMiddleware::create($app, 'auth.login.form');
 
+   // Area Device Account authorization checks
+   $deviceGuard = \Tournament\Middleware\AreaDeviceAccessGuard::create($app);
+
    /**********************
     * Route setup
     */
@@ -276,7 +279,7 @@ return function (\Slim\App $app)
    $app->post('/device/login', [AreaDeviceAuthController::class, 'login'])->setName('device.login.attempt');
    $app->get('/device/logout', [AreaDeviceAuthController::class, 'logout'])->setName('device.logout');
 
-   $app->group('/device', function (RouteCollectorProxy $device_grp) use ($policyGuard)
+   $app->group('/device', function (RouteCollectorProxy $device_grp) use ($deviceGuard, $policyGuard)
    {
       $device_grp->get('/category[/]', [AreaDeviceViewController::class, 'showCategories'])->setName('device.categories.index');
 
@@ -303,7 +306,8 @@ return function (\Slim\App $app)
             $mgrp->delete('/pool/{pool}/delete/{decision_round}', [AreaDeviceViewController::class, 'deletePoolDecisionRound'])->setName('device.categories.pools.decision.delete');
          })
          ->add($policyGuard->for(TournamentAction::RecordResults));
-      });
+      })
+      ->add($deviceGuard);
    })
    ->add($policyGuard->as(AuthType::DEVICE));
 };


### PR DESCRIPTION
move access guarding for area device accounts into a dedicated middleware, instead of doing it on controller level.